### PR TITLE
Inline non-template functions

### DIFF
--- a/src/GaussNewton.h
+++ b/src/GaussNewton.h
@@ -13,7 +13,7 @@ namespace FittingAlgorithms{
     using vector = Eigen::VectorXd;
     using matrix = Eigen::MatrixXd;
     
-    constexpr double EPSILON = sqrt(std::numeric_limits<double>::epsilon());
+    static double EPSILON = sqrt(std::numeric_limits<double>::epsilon());
     
     struct Parameters{
       int maxIterations     = 100;
@@ -30,7 +30,7 @@ namespace FittingAlgorithms{
 
 
     // Function to convert StringDoubleMap to Eigen::VectorXd
-    vector mapToEigen(const StringDoubleMap& initialGuesses) {
+    inline vector mapToEigen(const StringDoubleMap& initialGuesses) {
       
       std::size_t total_size = initialGuesses.size();
       
@@ -48,7 +48,7 @@ namespace FittingAlgorithms{
 
   
     // Function to update a StringDoubleMap with values from an Eigen::VectorXd
-    void updateMapFromEigen(StringDoubleMap& m, const vector& eigenVec) {
+    inline void updateMapFromEigen(StringDoubleMap& m, const vector& eigenVec) {
       // Ensure that the size of the Eigen::VectorXd matches the size of the std::map
       if (m.size() != int(eigenVec.size())) {
         std::cerr << "Error: The size of the vector (" << eigenVec.size()

--- a/src/ParallelTempering.h
+++ b/src/ParallelTempering.h
@@ -34,7 +34,7 @@ namespace FittingAlgorithms{
       }
     }
     
-    std::string getRandomParameter(const StringDoubleMap& parameters) {
+    inline std::string getRandomParameter(const StringDoubleMap& parameters) {
       int nParameters = parameters.size();
       if (nParameters == 0) {
         throw std::runtime_error("The parameters map is empty");
@@ -48,8 +48,8 @@ namespace FittingAlgorithms{
       return it->first;
     }
 
-    StringDoubleMap proposeNewFittingParameters(const StringDoubleMap currentFittingParameters,
-                                                const double jumpSize){
+    inline StringDoubleMap proposeNewFittingParameters(const StringDoubleMap currentFittingParameters,
+                          const double jumpSize){
 
       
       std::string param                    = getRandomParameter(currentFittingParameters);
@@ -62,12 +62,12 @@ namespace FittingAlgorithms{
       return newFittingParameters;
     }
 
-    void updateFittingParameters(StringDoubleMap &fittingParameters,
-                                 StringDoubleMap newFittingParameters,
-                                 double oldError,
-                                 double &newError,
-                                 double temperature,
-                                 double &jumpSize){
+    inline void updateFittingParameters(StringDoubleMap &fittingParameters,
+                   StringDoubleMap newFittingParameters,
+                   double oldError,
+                   double &newError,
+                   double temperature,
+                   double &jumpSize){
       
       if (newError < oldError){
         fittingParameters = newFittingParameters;
@@ -83,10 +83,10 @@ namespace FittingAlgorithms{
       }
     }
     
-    void tryToSwapTemperatures(std::vector<double>& temperatures,
-                               std::vector<std::map<std::string, double>>& allFittingParameters,
-                               std::vector<std::map<std::string, double>>& optimalFittingParameters,
-                               std::vector<double>& errors) {
+    inline void tryToSwapTemperatures(std::vector<double>& temperatures,
+                   std::vector<std::map<std::string, double>>& allFittingParameters,
+                   std::vector<std::map<std::string, double>>& optimalFittingParameters,
+                   std::vector<double>& errors) {
       int numTemperatures = temperatures.size();
       bool shouldTryToSwap = true;
       
@@ -131,10 +131,10 @@ namespace FittingAlgorithms{
     }
 
     // Helper function to update optimal parameters for a given temperature
-    void updateOptimalParameters(int tempIdx, double currentError,
-                                 std::vector<double>& optimalErrors,
-                                 const std::vector<StringDoubleMap>& allFittingParameters,
-                                 std::vector<StringDoubleMap>& optimalFittingParameters) {
+    inline void updateOptimalParameters(int tempIdx, double currentError,
+                   std::vector<double>& optimalErrors,
+                   const std::vector<StringDoubleMap>& allFittingParameters,
+                   std::vector<StringDoubleMap>& optimalFittingParameters) {
       if (currentError < optimalErrors[tempIdx]) {
         optimalErrors[tempIdx] = currentError;
         optimalFittingParameters[tempIdx] = allFittingParameters.at(tempIdx);
@@ -142,11 +142,11 @@ namespace FittingAlgorithms{
     }
     
     // Helper function to print step progress
-    void printStepProgress(int step, int maxSteps,
-                           const std::chrono::high_resolution_clock::time_point& start,
-                           double elapsedTime,
-                           const std::vector<double>& optimalErrors,
-                           const std::vector<StringDoubleMap>& optimalFittingParameters) {
+    inline void printStepProgress(int step, int maxSteps,
+                 const std::chrono::high_resolution_clock::time_point& start,
+                 double elapsedTime,
+                 const std::vector<double>& optimalErrors,
+                 const std::vector<StringDoubleMap>& optimalFittingParameters) {
       std::cout << "Step " << step << "/" << maxSteps << std::endl;
       std::cout << "Elapsed time: " << elapsedTime << " seconds" << std::endl;
       
@@ -170,11 +170,11 @@ namespace FittingAlgorithms{
     }
 
     // Helper function to check and update the best parameters
-    void checkAndUpdateBestParameters(const std::vector<double>& optimalErrors,
-                                      const std::vector<StringDoubleMap>& optimalFittingParameters,
-                                      double& minError, StringDoubleMap& bestParameters,
-                                      int& stepsSameError, bool& minErrorChanged,
-                                      const Parameters& params) {
+    inline void checkAndUpdateBestParameters(const std::vector<double>& optimalErrors,
+                      const std::vector<StringDoubleMap>& optimalFittingParameters,
+                      double& minError, StringDoubleMap& bestParameters,
+                      int& stepsSameError, bool& minErrorChanged,
+                      const Parameters& params) {
       minErrorChanged = false; // Reset the flag
       for (size_t i = 0; i < optimalErrors.size(); ++i) {
         if (optimalErrors[i] < minError) {


### PR DESCRIPTION
This change is required to avoid duplicate definitions when using this library in non-header only compilations.

I also fixed the issue in #1 
Closes #1 